### PR TITLE
multichain

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Juicebox projects can use an ENS address as their project's "handle" in frontend
     <li><a href="#description">Description</a></li>
   <ul>
     <li><a href="#motivation">Motivation</a></li>
+    <li><a href="#reading-handles">Reading Handles</a></li>
     <li><a href="#text-record-and-multichain">Text Record and Multichain</a></li>
     </ul>
     <li><a href="#example-usage">Example Usage</a></li>
@@ -142,6 +143,12 @@ nana-project-handles/
 
 Handles are easier to remember than IDs, but leaving this to clients could get messy. ENS names are often used as handles in the Ethereum ecosystem, because they can have _text records_ – arbitrary key-value text pairs which can be accessed onchain. If Juicebox frontend clients were to trust ENS text records alone as a source of truth, anyone could associate their ENS handle with any Juicebox project, and could use this to mislead others. Therefore, we need a two-way association between Juicebox projects and ENS names. The `JBProjectHandles` contract is the "reverse record" – it allows a Juicebox project's owner to associate their project with an ENS name. If an ENS name has a text record pointing to a Juicebox project, and the project points to that ENS name through the `JBProjectHandles` contract, the ENS name is the project's handle.
 
+### Reading Handles
+
+Clients can use [`JBProjectHandles.handleOf(…)`](https://github.com/Bananapus/nana-project-handles/blob/main/src/JBProjectHandles.sol#L61) to check a project's handle. The function only returns the handle if it is verified, and returns an empty string otherwise.
+
+`JBProjectHandles` is only deployed on Ethereum mainnet, but it manages handles for Juicebox projects on all EVM-compatible networks.
+
 ### Text Record and Multichain
 
 The canonical ENS registry and the `JBProjectHandles` contract are only available on Ethereum mainnet, but Juicebox projects can be deployed on several EVM-compatible networks. To allow project owners to set their handles on multiple chains, the text record specifies both the chain ID and the project ID.
@@ -176,4 +183,14 @@ JBProjectHandles.setEnsNamePartsFor({
 });
 ```
 
-Now, clients associate his project with `project.jeff.eth`.
+Now, frontend clients will associate his project with `project.jeff.eth`. To read the handle, a client can call `handleOf(…)`:
+
+```solidity
+JBProjectHandles.handleOf({
+  chainId: 10,
+  projectId: 5,
+  projectOwner: 0x123… // jeff.eth
+});
+```
+
+This will return `project.jeff.eth` if the handle is verified, and an empty string otherwise.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,34 @@
 # Bananapus Project Handles
 
-Juicebox projects can use an ENS address as their project's "handle" in frontend clients like [juicebox.money](https://juicebox.money). To make this association, they must first set their `juicebox_project` ENS text record to their project's ID.
+Juicebox projects can use an ENS address as their project's "handle" in frontend clients like [juicebox.money](https://juicebox.money). To make this association, they must set their `juicebox_project` ENS name's text record to their project's ID. The `JBProjectHandles` contract manages reverse records that point from project IDs to ENS names. If the two records match, that ENS name is considered the project's handle, and is shown in frontend clients.
 
-This `JBProjectHandles` contract manages reverse records that point from project IDs to ENS nodes. If the two records match, that ENS is considered the project's handle.
+<details>
+  <summary>Table of Contents</summary>
+  <ol>
+    <li><a href="#usage">Usage</a></li>
+  <ul>
+    <li><a href="#install">Install</a></li>
+    <li><a href="#develop">Develop</a></li>
+    <li><a href="#scripts">Scripts</a></li>
+    <li><a href="#deployments">Deployments</a></li>
+    <li><a href="#tips">Tips</a></li>
+    </ul>
+    <li><a href="#repository-layout">Repository Layout</a></li>
+    <li><a href="#description">Description</a></li>
+  <ul>
+    <li><a href="#motivation">Motivation</a></li>
+    <li><a href="#text-record-and-multichain">Text Record and Multichain</a></li>
+    </ul>
+    <li><a href="#example-usage">Example Usage</a></li>
+  </ul>
+  </ol>
+</details>
 
 _If you're having trouble understanding this contract, take a look at the [core protocol contracts](https://github.com/Bananapus/nana-core) and the [documentation](https://docs.juicebox.money/) first. If you have questions, reach out on [Discord](https://discord.com/invite/ErQYmth4dS)._
 
-## Install
+## Usage
+
+### Install
 
 How to install `nana-project-handles` in another project.
 
@@ -24,7 +46,7 @@ forge install Bananapus/nana-project-handles
 
 If you're using `forge` to manage dependencies, add `@bananapus/project-handles/=lib/nana-project-handles/` to `remappings.txt`. You'll also need to install `nana-project-handles`' dependencies and add similar remappings for them.
 
-## Develop
+### Develop
 
 `nana-project-handles` uses [npm](https://www.npmjs.com/) (version >=20.0.0) for package management and the [Foundry](https://github.com/foundry-rs/foundry) development toolchain for builds, tests, and deployments. To get set up, [install Node.js](https://nodejs.org/en/download) and install [Foundry](https://github.com/foundry-rs/foundry):
 
@@ -35,7 +57,7 @@ curl -L https://foundry.paradigm.xyz | sh
 You can download and install dependencies with:
 
 ```bash
-npm install && forge install
+npm ci && forge install
 ```
 
 If you run into trouble with `forge install`, try using `git submodule update --init --recursive` to ensure that nested submodules have been properly initialized.
@@ -53,3 +75,105 @@ Some useful commands:
 | `forge clean`         | Remove the build artifacts and cache directories.   |
 
 To learn more, visit the [Foundry Book](https://book.getfoundry.sh/) docs.
+
+### Scripts
+
+For convenience, several utility commands are available in `package.json`.
+
+| Command             | Description                            |
+| ------------------- | -------------------------------------- |
+| `npm test`          | Run local tests.                       |
+| `npm run test:fork` | Run fork tests (for use in CI).        |
+| `npm run coverage`  | Generate an LCOV test coverage report. |
+
+### Deployments
+
+To deploy, you'll need to set up a `.env` file based on `.example.env`. Then run one of the following commands:
+
+| Command                           | Description                        |
+| --------------------------------- | ---------------------------------- |
+| `npm run deploy:ethereum-mainnet` | Deploy to Ethereum mainnet         |
+| `npm run deploy:ethereum-sepolia` | Deploy to Ethereum Sepolia testnet |
+| `npm run deploy:optimism-mainnet` | Deploy to Optimism mainnet         |
+| `npm run deploy:optimism-sepolia` | Deploy to Optimism testnet         |
+
+### Tips
+
+To view test coverage, run `npm run coverage` to generate an LCOV test report. You can use an extension like [Coverage Gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters) to view coverage in your editor.
+
+If you're using Nomic Foundation's [Solidity](https://marketplace.visualstudio.com/items?itemName=NomicFoundation.hardhat-solidity) extension in VSCode, you may run into LSP errors because the extension cannot find dependencies outside of `lib`. You can often fix this by running:
+
+```bash
+forge remappings >> remappings.txt
+```
+
+This makes the extension aware of default remappings.
+
+## Repository Layout
+
+The root directory contains this README, an MIT license, and config files.
+
+The important source directories are:
+
+```
+nana-project-handles/
+├── script/
+│   └── Deploy.sol - The deployment script.
+├── src/
+│   ├── JBProjectHandles.sol - The main JBProjectHandles contract.
+│   └── interfaces/
+│       └── IJBProjectHandles.sol - The project handles interface.
+└── test/
+    └── JBProjectHandles.t.sol - Unit tests.
+```
+
+Other directories:
+
+```
+nana-project-handles/
+├── .github/
+│   └── workflows/ - CI/CD workflows.
+└── broadcast/ - Deployment logs.
+```
+
+## Description
+
+### Motivation
+
+Handles are easier to remember than IDs, but leaving this to clients could get messy. ENS names are often used as handles in the Ethereum ecosystem, because they can have _text records_ – arbitrary key-value text pairs which can be accessed onchain. If Juicebox frontend clients were to trust ENS text records alone as a source of truth, anyone could associate their ENS handle with any Juicebox project, and could use this to mislead others. Therefore, we need a two-way association between Juicebox projects and ENS names. The `JBProjectHandles` contract is the "reverse record" – it allows a Juicebox project's owner to associate their project with an ENS name. If an ENS name has a text record pointing to a Juicebox project, and the project points to that ENS name through the `JBProjectHandles` contract, the ENS name is the project's handle.
+
+### Text Record and Multichain
+
+The canonical ENS registry and the `JBProjectHandles` contract are only available on Ethereum mainnet, but Juicebox projects can be deployed on several EVM-compatible networks. To allow project owners to set their handles on multiple chains, the text record specifies both the chain ID and the project ID.
+
+To point an ENS name at a Juicebox project, use the name's `juicebox` text record, with the format `chainId:projectId`. For example, to point `jeff.eth` to project ID #5 on Optimism mainnet (which has chain ID 10), `jeff.eth` must have its `juicebox` text record set to `10:5`.
+
+To point a Juicebox project at an ENS name, the project's owner must call [`JBProjectHandles.setEnsNamePartsFor(...)`](https://github.com/Bananapus/nana-project-handles/blob/main/src/JBProjectHandles.sol#L113):
+
+```solidity
+/// @notice Associate an ENS name with a project.
+/// @dev ["jbx", "dao", "foo"] represents foo.dao.jbx.eth.
+/// @dev Only a project's owner can set its ENS name parts.
+/// @param chainId The chain ID of the network on which the project ID exists.
+/// @param projectId The ID of the project to set an ENS handle for.
+/// @param parts The parts of the ENS domain to use as the project handle, excluding the trailing .eth.
+function setEnsNamePartsFor(uint256 chainId, uint256 projectId, string[] memory parts) external override { ... }
+```
+
+To point project #5 on Optimism mainnet back at his ENS, Jeff would have to call `JBProjectHandles.setEnsNamePartsFor(10, 5, ["jeff"])`. The same address which owns the project on Optimism must call `setEnsNamePartsFor(…)` on mainnet. If the project's owner changes, the new owner must call `setEnsNamePartsFor(…)` again.
+
+## Example Usage
+
+1. `jeff.eth` deploys project ID #5 on Optimism mainnet. He wants to set its handle as `project.jeff.eth`.
+2. To point his ENS at his Juicebox project, he calls `PublicResolver.setText(…)` on the [ENS website](https://app.ens.domains/). He sets the `juicebox` text record for `project.jeff.eth` to `10:5`.
+3. To point his project at his ENS, he calls `setEnsNamePartsFor(…)`:
+
+```solidity
+JBProjectHandles.setEnsNamePartsFor({
+  chainId: 10, // Optimism mainnet
+  projectId: 5,
+  parts: ["project", "jeff"]
+});
+```
+
+Now, clients associate his project with `project.jeff.eth`.

--- a/README.md
+++ b/README.md
@@ -158,13 +158,13 @@ To point an ENS name at a Juicebox project, use the name's `juicebox` text recor
 To point a Juicebox project at an ENS name, the project's owner must call [`JBProjectHandles.setEnsNamePartsFor(...)`](https://github.com/Bananapus/nana-project-handles/blob/main/src/JBProjectHandles.sol#L113):
 
 ```solidity
-/// @notice Associate an ENS name with a project.
-/// @dev ["jbx", "dao", "foo"] represents foo.dao.jbx.eth.
-/// @dev Only a project's owner can set its ENS name parts.
-/// @param chainId The chain ID of the network on which the project ID exists.
+/// @notice Point from a Juicebox project to an ENS node.
+/// @dev The `parts` ["jbx", "dao", "foo"] represents foo.dao.jbx.eth.
+/// @dev The project's owner must call this function to set its ENS name parts.
+/// @param chainId The chain ID of the network the project is on.
 /// @param projectId The ID of the project to set an ENS handle for.
 /// @param parts The parts of the ENS domain to use as the project handle, excluding the trailing .eth.
-function setEnsNamePartsFor(uint256 chainId, uint256 projectId, string[] memory parts) external override { ... }
+function setEnsNamePartsFor(uint256 chainId, uint256 projectId, string[] memory parts) external override { … }
 ```
 
 To point project #5 on Optimism mainnet back at his ENS, Jeff would have to call `JBProjectHandles.setEnsNamePartsFor(10, 5, ["jeff"])`. The same address which owns the project on Optimism must call `setEnsNamePartsFor(…)` on mainnet. If the project's owner changes, the new owner must call `setEnsNamePartsFor(…)` again.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Bananapus Project Handles
 
-Juicebox projects can use an ENS address as their project's "handle" in frontend clients like [juicebox.money](https://juicebox.money). To make this association, they must first set their `juicebox_project` ENS text record to their project's ID.
+Juicebox projects can use an ENS address as their project's "handle" in frontend clients like [juicebox.money](https://juicebox.money). To make this association, they must first set their `juicebox` ENS text record to their project's ID.
 
 This `JBProjectHandles` contract manages reverse records that point from project IDs to ENS nodes. If the two records match, that ENS is considered the project's handle.
 

--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -39,7 +39,7 @@ contract Deploy is Script {
         );
 
         vm.broadcast();
-        new JBProjectHandles(IJBProjects(projectAddress), address(0x0));
+        new JBProjectHandles(address(0x0));
     }
 
     /// @notice Get the address of a contract that was deployed by the Deploy script.

--- a/script/Deploy.sol
+++ b/script/Deploy.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.16;
 
 import {Script, stdJson} from "forge-std/Script.sol";
-import {IJBPermissions} from "@bananapus/core/src/interfaces/IJBPermissions.sol";
 import {IJBProjects} from "@bananapus/core/src/interfaces/IJBProjects.sol";
 
 import "../src/JBProjectHandles.sol";
@@ -39,13 +38,8 @@ contract Deploy is Script {
             "JBProjects"
         );
 
-        address permissionsAddress = _getDeploymentAddress(
-            string.concat("node_modules/@bananapus/core/broadcast/Deploy.s.sol/", chain, "/run-latest.json"),
-            "JBPermissions"
-        );
-
         vm.broadcast();
-        new JBProjectHandles(IJBProjects(projectAddress), IJBPermissions(permissionsAddress));
+        new JBProjectHandles(IJBProjects(projectAddress), address(0x0));
     }
 
     /// @notice Get the address of a contract that was deployed by the Deploy script.

--- a/src/JBProjectHandles.sol
+++ b/src/JBProjectHandles.sol
@@ -9,7 +9,9 @@ import {ERC2771Context} from "@openzeppelin/contracts/metatx/ERC2771Context.sol"
 import {IJBProjects} from "@bananapus/core/src/interfaces/IJBProjects.sol";
 import {IJBProjectHandles} from "./interfaces/IJBProjectHandles.sol";
 
-/// @notice `JBProjectHandles` allows Juicebox project owners to associate their project with an ENS node. If that ENS node has a matching text record which points back to the project, clients will treat that ENS node as the project's handle.
+/// @notice `JBProjectHandles` allows Juicebox project owners to associate their project with an ENS node. If that ENS
+/// node has a matching text record which points back to the project, clients will treat that ENS node as the project's
+/// handle.
 /// @dev By convention, clients read the `juicebox` text field of the ENS node with the format `chainId:projectId`.
 /// For example, project ID #5 on Optimism mainnet would be represented by a `juicebox` text record of `10:5`.
 contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
@@ -46,7 +48,8 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @dev The `ensParts` ["jbx", "dao", "foo"] represents foo.dao.jbx.eth.
     /// @custom:param chainId The chain ID of the network the project is on.
     /// @custom:param projectId The ID of the project to get the ENS parts of.
-    /// @custom:param projectOwner The address of the project's owner. This is the address which called `setEnsNamePartsFor(...)`, and must be the project's current owner for the handle to be valid.
+    /// @custom:param projectOwner The address of the project's owner. This is the address which called
+    /// `setEnsNamePartsFor(...)`, and must be the project's current owner for the handle to be valid.
     mapping(uint256 chainId => mapping(uint256 projectId => mapping(address projectOwner => string[] ensParts))) private
         _ensNamePartsOf;
 

--- a/src/JBProjectHandles.sol
+++ b/src/JBProjectHandles.sol
@@ -92,17 +92,7 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
         // Return empty string if text record from ENS name doesn't match projectId or chainId.
         if (
             keccak256(bytes(textRecord))
-                != keccak256(
-                    bytes(
-                        string.concat(
-                            Strings.toString(chainId),
-                            ":",
-                            Strings.toString(projectId),
-                            ":",
-                            Strings.toHexString(uint256(uint160(projectOwner)))
-                        )
-                    )
-                )
+                != keccak256(bytes(string.concat(Strings.toString(chainId), ":", Strings.toString(projectId))))
         ) return "";
 
         // Format the handle from the name parts.

--- a/src/JBProjectHandles.sol
+++ b/src/JBProjectHandles.sol
@@ -32,13 +32,6 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     ENS public constant ENS_REGISTRY = ENS(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e);
 
     //*********************************************************************//
-    // --------------- public immutable stored properties ---------------- //
-    //*********************************************************************//
-
-    /// @notice A contract which mints ERC-721's that represent project ownership and transfers.
-    IJBProjects public immutable override PROJECTS;
-
-    //*********************************************************************//
     // --------------------- private stored properties ------------------- //
     //*********************************************************************//
 
@@ -121,11 +114,8 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     // ---------------------------- constructor -------------------------- //
     //*********************************************************************//
 
-    /// @param projects A contract which mints ERC-721's that represent project ownership and transfers.
     /// @param trustedForwarder The trusted forwarder for the ERC2771Context.
-    constructor(IJBProjects projects, address trustedForwarder) ERC2771Context(trustedForwarder) {
-        PROJECTS = projects;
-    }
+    constructor(address trustedForwarder) ERC2771Context(trustedForwarder) {}
 
     //*********************************************************************//
     // --------------------- external transactions ----------------------- //

--- a/src/JBProjectHandles.sol
+++ b/src/JBProjectHandles.sol
@@ -42,8 +42,8 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @custom:param chainId The chain ID of the network the project is on.
     /// @custom:param projectId The ID of the project to get the ENS parts of.
     /// @custom:param setter The address that set the requested `ensParts`. This should be the project's current owner.
-    mapping(uint256 chainId => mapping(uint256 projectId => mapping(address setter => string[] ensParts)))
-        private _ensNamePartsOf;
+    mapping(uint256 chainId => mapping(uint256 projectId => mapping(address setter => string[] ensParts))) private
+        _ensNamePartsOf;
 
     //*********************************************************************//
     // ------------------------- external views -------------------------- //
@@ -59,11 +59,14 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
         uint256 chainId,
         uint256 projectId,
         address setter
-    ) external view override returns (string memory) {
+    )
+        external
+        view
+        override
+        returns (string memory)
+    {
         // Get a reference to the project's ENS name parts.
-        string[] memory ensNameParts = _ensNamePartsOf[chainId][projectId][
-            setter
-        ];
+        string[] memory ensNameParts = _ensNamePartsOf[chainId][projectId][setter];
 
         // Return an empty string if not found.
         if (ensNameParts.length == 0) return "";
@@ -82,16 +85,8 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
 
         // Return empty string if text record from ENS name doesn't match `projectId` and `chainId`.
         if (
-            keccak256(bytes(textRecord)) !=
-            keccak256(
-                bytes(
-                    string.concat(
-                        Strings.toString(chainId),
-                        ":",
-                        Strings.toString(projectId)
-                    )
-                )
-            )
+            keccak256(bytes(textRecord))
+                != keccak256(bytes(string.concat(Strings.toString(chainId), ":", Strings.toString(projectId))))
         ) return "";
 
         // Format the handle from the name parts.
@@ -107,7 +102,12 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
         uint256 chainId,
         uint256 projectId,
         address setter
-    ) external view override returns (string[] memory) {
+    )
+        external
+        view
+        override
+        returns (string[] memory)
+    {
         return _ensNamePartsOf[chainId][projectId][setter];
     }
 
@@ -128,11 +128,7 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @param chainId The chain ID of the network the project is on.
     /// @param projectId The ID of the project to set an ENS handle for.
     /// @param parts The parts of the ENS domain to use as the project handle, excluding the trailing .eth.
-    function setEnsNamePartsFor(
-        uint256 chainId,
-        uint256 projectId,
-        string[] memory parts
-    ) external override {
+    function setEnsNamePartsFor(uint256 chainId, uint256 projectId, string[] memory parts) external override {
         // Get a reference to the number of parts are in the ENS name.
         uint256 partsLength = parts.length;
 
@@ -147,12 +143,7 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
         // Store the parts.
         _ensNamePartsOf[chainId][projectId][_msgSender()] = parts;
 
-        emit SetEnsNameParts(
-            projectId,
-            _formatHandle(parts),
-            parts,
-            _msgSender()
-        );
+        emit SetEnsNameParts(projectId, _formatHandle(parts), parts, _msgSender());
     }
 
     //*********************************************************************//
@@ -162,18 +153,14 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @notice Formats ENS name parts into a handle.
     /// @param ensNameParts The ENS name parts to format into a handle.
     /// @return handle The formatted ENS handle.
-    function _formatHandle(
-        string[] memory ensNameParts
-    ) internal pure returns (string memory handle) {
+    function _formatHandle(string[] memory ensNameParts) internal pure returns (string memory handle) {
         // Get a reference to the number of parts are in the ENS name.
         uint256 partsLength = ensNameParts.length;
 
         // Concatenate each name part.
         for (uint256 i = 1; i <= partsLength; i++) {
             // Compute the handle.
-            handle = string(
-                abi.encodePacked(handle, ensNameParts[partsLength - i])
-            );
+            handle = string(abi.encodePacked(handle, ensNameParts[partsLength - i]));
 
             // Add a dot if this part isn't the last.
             if (i < partsLength) handle = string(abi.encodePacked(handle, "."));
@@ -184,25 +171,16 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @dev See https://eips.ethereum.org/EIPS/eip-137.
     /// @param ensNameParts The parts of an ENS name to hash.
     /// @return namehash The namehash for an ENS name parts.
-    function _namehash(
-        string[] memory ensNameParts
-    ) internal pure returns (bytes32 namehash) {
+    function _namehash(string[] memory ensNameParts) internal pure returns (bytes32 namehash) {
         // Hash the trailing "eth" suffix.
-        namehash = keccak256(
-            abi.encodePacked(namehash, keccak256(abi.encodePacked("eth")))
-        );
+        namehash = keccak256(abi.encodePacked(namehash, keccak256(abi.encodePacked("eth"))));
 
         // Get a reference to the number of parts are in the ENS name.
         uint256 nameLength = ensNameParts.length;
 
         // Hash each part.
         for (uint256 i; i < nameLength; i++) {
-            namehash = keccak256(
-                abi.encodePacked(
-                    namehash,
-                    keccak256(abi.encodePacked(ensNameParts[i]))
-                )
-            );
+            namehash = keccak256(abi.encodePacked(namehash, keccak256(abi.encodePacked(ensNameParts[i]))));
         }
     }
 
@@ -219,13 +197,7 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     }
 
     /// @dev ERC-2771 specifies the context as being a single address (20 bytes).
-    function _contextSuffixLength()
-        internal
-        view
-        virtual
-        override
-        returns (uint256)
-    {
+    function _contextSuffixLength() internal view virtual override returns (uint256) {
         return super._contextSuffixLength();
     }
 }

--- a/src/JBProjectHandles.sol
+++ b/src/JBProjectHandles.sol
@@ -29,8 +29,7 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
 
     /// @notice The ENS registry contract address.
     /// @dev Same on every network
-    ENS public constant ENS_REGISTRY =
-        ENS(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e);
+    ENS public constant ENS_REGISTRY = ENS(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e);
 
     //*********************************************************************//
     // --------------- public immutable stored properties ---------------- //
@@ -48,8 +47,8 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @custom:param chainId The chain ID of the network on which the project ID exists.
     /// @custom:param projectId The ID of the project to get an ENS name for.
     /// @custom:param projectOwner The address of the project's owner.
-    mapping(uint256 chainId => mapping(uint256 projectId => mapping(address projectOwner => string[] ensParts)))
-        private _ensNamePartsOf;
+    mapping(uint256 chainId => mapping(uint256 projectId => mapping(address projectOwner => string[] ensParts))) private
+        _ensNamePartsOf;
 
     //*********************************************************************//
     // ------------------------- external views -------------------------- //
@@ -66,11 +65,14 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
         uint256 chainId,
         uint256 projectId,
         address projectOwner
-    ) external view override returns (string memory) {
+    )
+        external
+        view
+        override
+        returns (string memory)
+    {
         // Get a reference to the project's ENS name parts.
-        string[] memory ensNameParts = _ensNamePartsOf[chainId][projectId][
-            projectOwner
-        ];
+        string[] memory ensNameParts = _ensNamePartsOf[chainId][projectId][projectOwner];
 
         // Return an empty string if not found.
         if (ensNameParts.length == 0) return "";
@@ -85,25 +87,22 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
         if (textResolver == address(0)) return "";
 
         // Find the projectId that the text record of the ENS name is mapped to.
-        string memory textRecord = ITextResolver(textResolver).text(
-            hashedName,
-            TEXT_KEY
-        );
+        string memory textRecord = ITextResolver(textResolver).text(hashedName, TEXT_KEY);
 
         // Return empty string if text record from ENS name doesn't match projectId or chainId.
         if (
-            keccak256(bytes(textRecord)) !=
-            keccak256(
-                bytes(
-                    string.concat(
-                        Strings.toString(chainId),
-                        ":",
-                        Strings.toString(projectId),
-                        ":",
-                        Strings.toHexString(uint256(uint160(projectOwner)))
+            keccak256(bytes(textRecord))
+                != keccak256(
+                    bytes(
+                        string.concat(
+                            Strings.toString(chainId),
+                            ":",
+                            Strings.toString(projectId),
+                            ":",
+                            Strings.toHexString(uint256(uint160(projectOwner)))
+                        )
                     )
                 )
-            )
         ) return "";
 
         // Format the handle from the name parts.
@@ -119,7 +118,12 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
         uint256 chainId,
         uint256 projectId,
         address projectOwner
-    ) external view override returns (string[] memory) {
+    )
+        external
+        view
+        override
+        returns (string[] memory)
+    {
         return _ensNamePartsOf[chainId][projectId][projectOwner];
     }
 
@@ -129,10 +133,7 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
 
     /// @param projects A contract which mints ERC-721's that represent project ownership and transfers.
     /// @param trustedForwarder The trusted forwarder for the ERC2771Context.
-    constructor(
-        IJBProjects projects,
-        address trustedForwarder
-    ) ERC2771Context(trustedForwarder) {
+    constructor(IJBProjects projects, address trustedForwarder) ERC2771Context(trustedForwarder) {
         PROJECTS = projects;
     }
 
@@ -146,11 +147,7 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @param chainId The chain ID of the network on which the project ID exists.
     /// @param projectId The ID of the project to set an ENS handle for.
     /// @param parts The parts of the ENS domain to use as the project handle, excluding the trailing .eth.
-    function setEnsNamePartsFor(
-        uint256 chainId,
-        uint256 projectId,
-        string[] memory parts
-    ) external override {
+    function setEnsNamePartsFor(uint256 chainId, uint256 projectId, string[] memory parts) external override {
         // Get a reference to the number of parts are in the ENS name.
         uint256 partsLength = parts.length;
 
@@ -165,12 +162,7 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
         // Store the parts.
         _ensNamePartsOf[chainId][projectId][_msgSender()] = parts;
 
-        emit SetEnsNameParts(
-            projectId,
-            _formatHandle(parts),
-            parts,
-            _msgSender()
-        );
+        emit SetEnsNameParts(projectId, _formatHandle(parts), parts, _msgSender());
     }
 
     //*********************************************************************//
@@ -180,18 +172,14 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @notice Formats ENS name parts into a handle.
     /// @param ensNameParts The ENS name parts to format into a handle.
     /// @return handle The formatted ENS handle.
-    function _formatHandle(
-        string[] memory ensNameParts
-    ) internal pure returns (string memory handle) {
+    function _formatHandle(string[] memory ensNameParts) internal pure returns (string memory handle) {
         // Get a reference to the number of parts are in the ENS name.
         uint256 partsLength = ensNameParts.length;
 
         // Concatenate each name part.
         for (uint256 i = 1; i <= partsLength; i++) {
             // Compute the handle.
-            handle = string(
-                abi.encodePacked(handle, ensNameParts[partsLength - i])
-            );
+            handle = string(abi.encodePacked(handle, ensNameParts[partsLength - i]));
 
             // Add a dot if this part isn't the last.
             if (i < partsLength) handle = string(abi.encodePacked(handle, "."));
@@ -202,25 +190,16 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @dev See https://eips.ethereum.org/EIPS/eip-137.
     /// @param ensNameParts The parts of an ENS name to hash.
     /// @return namehash The namehash for an ENS name parts.
-    function _namehash(
-        string[] memory ensNameParts
-    ) internal pure returns (bytes32 namehash) {
+    function _namehash(string[] memory ensNameParts) internal pure returns (bytes32 namehash) {
         // Hash the trailing "eth" suffix.
-        namehash = keccak256(
-            abi.encodePacked(namehash, keccak256(abi.encodePacked("eth")))
-        );
+        namehash = keccak256(abi.encodePacked(namehash, keccak256(abi.encodePacked("eth"))));
 
         // Get a reference to the number of parts are in the ENS name.
         uint256 nameLength = ensNameParts.length;
 
         // Hash each part.
         for (uint256 i; i < nameLength; i++) {
-            namehash = keccak256(
-                abi.encodePacked(
-                    namehash,
-                    keccak256(abi.encodePacked(ensNameParts[i]))
-                )
-            );
+            namehash = keccak256(abi.encodePacked(namehash, keccak256(abi.encodePacked(ensNameParts[i]))));
         }
     }
 
@@ -237,13 +216,7 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     }
 
     /// @dev ERC-2771 specifies the context as being a single address (20 bytes).
-    function _contextSuffixLength()
-        internal
-        view
-        virtual
-        override
-        returns (uint256)
-    {
+    function _contextSuffixLength() internal view virtual override returns (uint256) {
         return super._contextSuffixLength();
     }
 }

--- a/src/JBProjectHandles.sol
+++ b/src/JBProjectHandles.sol
@@ -25,11 +25,14 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     //*********************************************************************//
 
     /// @notice The key of the ENS text record.
-    string public constant override TEXT_KEY = "juicebox";
+    string public constant override TEXT_KEY_PREFIX = "juicebox";
+    string public constant override TEXT_KEY_PROJECT_ID_SUFFIX = ":projectId";
+    string public constant override TEXT_KEY_CHAIN_ID_SUFFIX = ":chainId";
 
     /// @notice The ENS registry contract address.
     /// @dev Same on every network
-    ENS public constant ENS_REGISTRY = ENS(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e);
+    ENS public constant ENS_REGISTRY =
+        ENS(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e);
 
     //*********************************************************************//
     // --------------- public immutable stored properties ---------------- //
@@ -47,8 +50,8 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @custom:param chainId The chain ID of the network on which the project ID exists.
     /// @custom:param projectId The ID of the project to get an ENS name for.
     /// @custom:param projectOwner The address of the project's owner.
-    mapping(uint256 chainId => mapping(uint256 projectId => mapping(address projectOwner => string[] ensParts))) private
-        _ensNamePartsOf;
+    mapping(uint256 chainId => mapping(uint256 projectId => mapping(address projectOwner => string[] ensParts)))
+        private _ensNamePartsOf;
 
     //*********************************************************************//
     // ------------------------- external views -------------------------- //
@@ -65,14 +68,11 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
         uint256 chainId,
         uint256 projectId,
         address projectOwner
-    )
-        external
-        view
-        override
-        returns (string memory)
-    {
+    ) external view override returns (string memory) {
         // Get a reference to the project's ENS name parts.
-        string[] memory ensNameParts = _ensNamePartsOf[chainId][projectId][projectOwner];
+        string[] memory ensNameParts = _ensNamePartsOf[chainId][projectId][
+            projectOwner
+        ];
 
         // Return an empty string if not found.
         if (ensNameParts.length == 0) return "";
@@ -87,17 +87,23 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
         if (textResolver == address(0)) return "";
 
         // Find the projectId that the text record of the ENS name is mapped to.
-        string memory textRecordProjectId =
-            ITextResolver(textResolver).text(hashedName, string.concat(TEXT_KEY, ":projectId"));
+        string memory textRecordProjectId = ITextResolver(textResolver).text(
+            hashedName,
+            string.concat(TEXT_KEY_PREFIX, TEXT_KEY_PROJECT_ID_SUFFIX)
+        );
 
         // Find the chainId that the text record of the ENS name is mapped to.
-        string memory textRecordChainId =
-            ITextResolver(textResolver).text(hashedName, string.concat(TEXT_KEY, ":chainId"));
+        string memory textRecordChainId = ITextResolver(textResolver).text(
+            hashedName,
+            string.concat(TEXT_KEY_PREFIX, TEXT_KEY_CHAIN_ID_SUFFIX)
+        );
 
         // Return empty string if text record from ENS name doesn't match projectId or chainId.
         if (
-            keccak256(bytes(textRecordProjectId)) != keccak256(bytes(Strings.toString(projectId)))
-                || keccak256(bytes(textRecordChainId)) != keccak256(bytes(Strings.toString(chainId)))
+            keccak256(bytes(textRecordProjectId)) !=
+            keccak256(bytes(Strings.toString(projectId))) ||
+            keccak256(bytes(textRecordChainId)) !=
+            keccak256(bytes(Strings.toString(chainId)))
         ) return "";
 
         // Format the handle from the name parts.
@@ -113,12 +119,7 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
         uint256 chainId,
         uint256 projectId,
         address projectOwner
-    )
-        external
-        view
-        override
-        returns (string[] memory)
-    {
+    ) external view override returns (string[] memory) {
         return _ensNamePartsOf[chainId][projectId][projectOwner];
     }
 
@@ -128,7 +129,10 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
 
     /// @param projects A contract which mints ERC-721's that represent project ownership and transfers.
     /// @param trustedForwarder The trusted forwarder for the ERC2771Context.
-    constructor(IJBProjects projects, address trustedForwarder) ERC2771Context(trustedForwarder) {
+    constructor(
+        IJBProjects projects,
+        address trustedForwarder
+    ) ERC2771Context(trustedForwarder) {
         PROJECTS = projects;
     }
 
@@ -142,7 +146,11 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @param chainId The chain ID of the network on which the project ID exists.
     /// @param projectId The ID of the project to set an ENS handle for.
     /// @param parts The parts of the ENS domain to use as the project handle, excluding the trailing .eth.
-    function setEnsNamePartsFor(uint256 chainId, uint256 projectId, string[] memory parts) external override {
+    function setEnsNamePartsFor(
+        uint256 chainId,
+        uint256 projectId,
+        string[] memory parts
+    ) external override {
         // Get a reference to the number of parts are in the ENS name.
         uint256 partsLength = parts.length;
 
@@ -157,7 +165,12 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
         // Store the parts.
         _ensNamePartsOf[chainId][projectId][_msgSender()] = parts;
 
-        emit SetEnsNameParts(projectId, _formatHandle(parts), parts, _msgSender());
+        emit SetEnsNameParts(
+            projectId,
+            _formatHandle(parts),
+            parts,
+            _msgSender()
+        );
     }
 
     //*********************************************************************//
@@ -167,14 +180,18 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @notice Formats ENS name parts into a handle.
     /// @param ensNameParts The ENS name parts to format into a handle.
     /// @return handle The formatted ENS handle.
-    function _formatHandle(string[] memory ensNameParts) internal pure returns (string memory handle) {
+    function _formatHandle(
+        string[] memory ensNameParts
+    ) internal pure returns (string memory handle) {
         // Get a reference to the number of parts are in the ENS name.
         uint256 partsLength = ensNameParts.length;
 
         // Concatenate each name part.
         for (uint256 i = 1; i <= partsLength; i++) {
             // Compute the handle.
-            handle = string(abi.encodePacked(handle, ensNameParts[partsLength - i]));
+            handle = string(
+                abi.encodePacked(handle, ensNameParts[partsLength - i])
+            );
 
             // Add a dot if this part isn't the last.
             if (i < partsLength) handle = string(abi.encodePacked(handle, "."));
@@ -185,16 +202,25 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @dev See https://eips.ethereum.org/EIPS/eip-137.
     /// @param ensNameParts The parts of an ENS name to hash.
     /// @return namehash The namehash for an ENS name parts.
-    function _namehash(string[] memory ensNameParts) internal pure returns (bytes32 namehash) {
+    function _namehash(
+        string[] memory ensNameParts
+    ) internal pure returns (bytes32 namehash) {
         // Hash the trailing "eth" suffix.
-        namehash = keccak256(abi.encodePacked(namehash, keccak256(abi.encodePacked("eth"))));
+        namehash = keccak256(
+            abi.encodePacked(namehash, keccak256(abi.encodePacked("eth")))
+        );
 
         // Get a reference to the number of parts are in the ENS name.
         uint256 nameLength = ensNameParts.length;
 
         // Hash each part.
         for (uint256 i; i < nameLength; i++) {
-            namehash = keccak256(abi.encodePacked(namehash, keccak256(abi.encodePacked(ensNameParts[i]))));
+            namehash = keccak256(
+                abi.encodePacked(
+                    namehash,
+                    keccak256(abi.encodePacked(ensNameParts[i]))
+                )
+            );
         }
     }
 
@@ -211,7 +237,13 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     }
 
     /// @dev ERC-2771 specifies the context as being a single address (20 bytes).
-    function _contextSuffixLength() internal view virtual override returns (uint256) {
+    function _contextSuffixLength()
+        internal
+        view
+        virtual
+        override
+        returns (uint256)
+    {
         return super._contextSuffixLength();
     }
 }

--- a/src/JBProjectHandles.sol
+++ b/src/JBProjectHandles.sol
@@ -31,8 +31,7 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
 
     /// @notice The ENS registry contract address.
     /// @dev Same on every network
-    ENS public constant ENS_REGISTRY =
-        ENS(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e);
+    ENS public constant ENS_REGISTRY = ENS(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e);
 
     //*********************************************************************//
     // --------------- public immutable stored properties ---------------- //
@@ -50,8 +49,8 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @custom:param chainId The chain ID of the network on which the project ID exists.
     /// @custom:param projectId The ID of the project to get an ENS name for.
     /// @custom:param projectOwner The address of the project's owner.
-    mapping(uint256 chainId => mapping(uint256 projectId => mapping(address projectOwner => string[] ensParts)))
-        private _ensNamePartsOf;
+    mapping(uint256 chainId => mapping(uint256 projectId => mapping(address projectOwner => string[] ensParts))) private
+        _ensNamePartsOf;
 
     //*********************************************************************//
     // ------------------------- external views -------------------------- //
@@ -68,11 +67,14 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
         uint256 chainId,
         uint256 projectId,
         address projectOwner
-    ) external view override returns (string memory) {
+    )
+        external
+        view
+        override
+        returns (string memory)
+    {
         // Get a reference to the project's ENS name parts.
-        string[] memory ensNameParts = _ensNamePartsOf[chainId][projectId][
-            projectOwner
-        ];
+        string[] memory ensNameParts = _ensNamePartsOf[chainId][projectId][projectOwner];
 
         // Return an empty string if not found.
         if (ensNameParts.length == 0) return "";
@@ -87,23 +89,17 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
         if (textResolver == address(0)) return "";
 
         // Find the projectId that the text record of the ENS name is mapped to.
-        string memory textRecordProjectId = ITextResolver(textResolver).text(
-            hashedName,
-            string.concat(TEXT_KEY_PREFIX, TEXT_KEY_PROJECT_ID_SUFFIX)
-        );
+        string memory textRecordProjectId =
+            ITextResolver(textResolver).text(hashedName, string.concat(TEXT_KEY_PREFIX, TEXT_KEY_PROJECT_ID_SUFFIX));
 
         // Find the chainId that the text record of the ENS name is mapped to.
-        string memory textRecordChainId = ITextResolver(textResolver).text(
-            hashedName,
-            string.concat(TEXT_KEY_PREFIX, TEXT_KEY_CHAIN_ID_SUFFIX)
-        );
+        string memory textRecordChainId =
+            ITextResolver(textResolver).text(hashedName, string.concat(TEXT_KEY_PREFIX, TEXT_KEY_CHAIN_ID_SUFFIX));
 
         // Return empty string if text record from ENS name doesn't match projectId or chainId.
         if (
-            keccak256(bytes(textRecordProjectId)) !=
-            keccak256(bytes(Strings.toString(projectId))) ||
-            keccak256(bytes(textRecordChainId)) !=
-            keccak256(bytes(Strings.toString(chainId)))
+            keccak256(bytes(textRecordProjectId)) != keccak256(bytes(Strings.toString(projectId)))
+                || keccak256(bytes(textRecordChainId)) != keccak256(bytes(Strings.toString(chainId)))
         ) return "";
 
         // Format the handle from the name parts.
@@ -119,7 +115,12 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
         uint256 chainId,
         uint256 projectId,
         address projectOwner
-    ) external view override returns (string[] memory) {
+    )
+        external
+        view
+        override
+        returns (string[] memory)
+    {
         return _ensNamePartsOf[chainId][projectId][projectOwner];
     }
 
@@ -129,10 +130,7 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
 
     /// @param projects A contract which mints ERC-721's that represent project ownership and transfers.
     /// @param trustedForwarder The trusted forwarder for the ERC2771Context.
-    constructor(
-        IJBProjects projects,
-        address trustedForwarder
-    ) ERC2771Context(trustedForwarder) {
+    constructor(IJBProjects projects, address trustedForwarder) ERC2771Context(trustedForwarder) {
         PROJECTS = projects;
     }
 
@@ -146,11 +144,7 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @param chainId The chain ID of the network on which the project ID exists.
     /// @param projectId The ID of the project to set an ENS handle for.
     /// @param parts The parts of the ENS domain to use as the project handle, excluding the trailing .eth.
-    function setEnsNamePartsFor(
-        uint256 chainId,
-        uint256 projectId,
-        string[] memory parts
-    ) external override {
+    function setEnsNamePartsFor(uint256 chainId, uint256 projectId, string[] memory parts) external override {
         // Get a reference to the number of parts are in the ENS name.
         uint256 partsLength = parts.length;
 
@@ -165,12 +159,7 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
         // Store the parts.
         _ensNamePartsOf[chainId][projectId][_msgSender()] = parts;
 
-        emit SetEnsNameParts(
-            projectId,
-            _formatHandle(parts),
-            parts,
-            _msgSender()
-        );
+        emit SetEnsNameParts(projectId, _formatHandle(parts), parts, _msgSender());
     }
 
     //*********************************************************************//
@@ -180,18 +169,14 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @notice Formats ENS name parts into a handle.
     /// @param ensNameParts The ENS name parts to format into a handle.
     /// @return handle The formatted ENS handle.
-    function _formatHandle(
-        string[] memory ensNameParts
-    ) internal pure returns (string memory handle) {
+    function _formatHandle(string[] memory ensNameParts) internal pure returns (string memory handle) {
         // Get a reference to the number of parts are in the ENS name.
         uint256 partsLength = ensNameParts.length;
 
         // Concatenate each name part.
         for (uint256 i = 1; i <= partsLength; i++) {
             // Compute the handle.
-            handle = string(
-                abi.encodePacked(handle, ensNameParts[partsLength - i])
-            );
+            handle = string(abi.encodePacked(handle, ensNameParts[partsLength - i]));
 
             // Add a dot if this part isn't the last.
             if (i < partsLength) handle = string(abi.encodePacked(handle, "."));
@@ -202,25 +187,16 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @dev See https://eips.ethereum.org/EIPS/eip-137.
     /// @param ensNameParts The parts of an ENS name to hash.
     /// @return namehash The namehash for an ENS name parts.
-    function _namehash(
-        string[] memory ensNameParts
-    ) internal pure returns (bytes32 namehash) {
+    function _namehash(string[] memory ensNameParts) internal pure returns (bytes32 namehash) {
         // Hash the trailing "eth" suffix.
-        namehash = keccak256(
-            abi.encodePacked(namehash, keccak256(abi.encodePacked("eth")))
-        );
+        namehash = keccak256(abi.encodePacked(namehash, keccak256(abi.encodePacked("eth"))));
 
         // Get a reference to the number of parts are in the ENS name.
         uint256 nameLength = ensNameParts.length;
 
         // Hash each part.
         for (uint256 i; i < nameLength; i++) {
-            namehash = keccak256(
-                abi.encodePacked(
-                    namehash,
-                    keccak256(abi.encodePacked(ensNameParts[i]))
-                )
-            );
+            namehash = keccak256(abi.encodePacked(namehash, keccak256(abi.encodePacked(ensNameParts[i]))));
         }
     }
 
@@ -237,13 +213,7 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     }
 
     /// @dev ERC-2771 specifies the context as being a single address (20 bytes).
-    function _contextSuffixLength()
-        internal
-        view
-        virtual
-        override
-        returns (uint256)
-    {
+    function _contextSuffixLength() internal view virtual override returns (uint256) {
         return super._contextSuffixLength();
     }
 }

--- a/src/JBProjectHandles.sol
+++ b/src/JBProjectHandles.sol
@@ -25,13 +25,12 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     //*********************************************************************//
 
     /// @notice The key of the ENS text record.
-    string public constant override TEXT_KEY_PREFIX = "juicebox";
-    string public constant override TEXT_KEY_PROJECT_ID_SUFFIX = ":projectId";
-    string public constant override TEXT_KEY_CHAIN_ID_SUFFIX = ":chainId";
+    string public constant override TEXT_KEY = "juicebox";
 
     /// @notice The ENS registry contract address.
     /// @dev Same on every network
-    ENS public constant ENS_REGISTRY = ENS(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e);
+    ENS public constant ENS_REGISTRY =
+        ENS(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e);
 
     //*********************************************************************//
     // --------------- public immutable stored properties ---------------- //
@@ -49,8 +48,8 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @custom:param chainId The chain ID of the network on which the project ID exists.
     /// @custom:param projectId The ID of the project to get an ENS name for.
     /// @custom:param projectOwner The address of the project's owner.
-    mapping(uint256 chainId => mapping(uint256 projectId => mapping(address projectOwner => string[] ensParts))) private
-        _ensNamePartsOf;
+    mapping(uint256 chainId => mapping(uint256 projectId => mapping(address projectOwner => string[] ensParts)))
+        private _ensNamePartsOf;
 
     //*********************************************************************//
     // ------------------------- external views -------------------------- //
@@ -67,14 +66,11 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
         uint256 chainId,
         uint256 projectId,
         address projectOwner
-    )
-        external
-        view
-        override
-        returns (string memory)
-    {
+    ) external view override returns (string memory) {
         // Get a reference to the project's ENS name parts.
-        string[] memory ensNameParts = _ensNamePartsOf[chainId][projectId][projectOwner];
+        string[] memory ensNameParts = _ensNamePartsOf[chainId][projectId][
+            projectOwner
+        ];
 
         // Return an empty string if not found.
         if (ensNameParts.length == 0) return "";
@@ -89,17 +85,25 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
         if (textResolver == address(0)) return "";
 
         // Find the projectId that the text record of the ENS name is mapped to.
-        string memory textRecordProjectId =
-            ITextResolver(textResolver).text(hashedName, string.concat(TEXT_KEY_PREFIX, TEXT_KEY_PROJECT_ID_SUFFIX));
-
-        // Find the chainId that the text record of the ENS name is mapped to.
-        string memory textRecordChainId =
-            ITextResolver(textResolver).text(hashedName, string.concat(TEXT_KEY_PREFIX, TEXT_KEY_CHAIN_ID_SUFFIX));
+        string memory textRecord = ITextResolver(textResolver).text(
+            hashedName,
+            TEXT_KEY
+        );
 
         // Return empty string if text record from ENS name doesn't match projectId or chainId.
         if (
-            keccak256(bytes(textRecordProjectId)) != keccak256(bytes(Strings.toString(projectId)))
-                || keccak256(bytes(textRecordChainId)) != keccak256(bytes(Strings.toString(chainId)))
+            keccak256(bytes(textRecord)) !=
+            keccak256(
+                bytes(
+                    string.concat(
+                        Strings.toString(chainId),
+                        ":",
+                        Strings.toString(projectId),
+                        ":",
+                        Strings.toHexString(uint256(uint160(projectOwner)))
+                    )
+                )
+            )
         ) return "";
 
         // Format the handle from the name parts.
@@ -115,12 +119,7 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
         uint256 chainId,
         uint256 projectId,
         address projectOwner
-    )
-        external
-        view
-        override
-        returns (string[] memory)
-    {
+    ) external view override returns (string[] memory) {
         return _ensNamePartsOf[chainId][projectId][projectOwner];
     }
 
@@ -130,7 +129,10 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
 
     /// @param projects A contract which mints ERC-721's that represent project ownership and transfers.
     /// @param trustedForwarder The trusted forwarder for the ERC2771Context.
-    constructor(IJBProjects projects, address trustedForwarder) ERC2771Context(trustedForwarder) {
+    constructor(
+        IJBProjects projects,
+        address trustedForwarder
+    ) ERC2771Context(trustedForwarder) {
         PROJECTS = projects;
     }
 
@@ -144,7 +146,11 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @param chainId The chain ID of the network on which the project ID exists.
     /// @param projectId The ID of the project to set an ENS handle for.
     /// @param parts The parts of the ENS domain to use as the project handle, excluding the trailing .eth.
-    function setEnsNamePartsFor(uint256 chainId, uint256 projectId, string[] memory parts) external override {
+    function setEnsNamePartsFor(
+        uint256 chainId,
+        uint256 projectId,
+        string[] memory parts
+    ) external override {
         // Get a reference to the number of parts are in the ENS name.
         uint256 partsLength = parts.length;
 
@@ -159,7 +165,12 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
         // Store the parts.
         _ensNamePartsOf[chainId][projectId][_msgSender()] = parts;
 
-        emit SetEnsNameParts(projectId, _formatHandle(parts), parts, _msgSender());
+        emit SetEnsNameParts(
+            projectId,
+            _formatHandle(parts),
+            parts,
+            _msgSender()
+        );
     }
 
     //*********************************************************************//
@@ -169,14 +180,18 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @notice Formats ENS name parts into a handle.
     /// @param ensNameParts The ENS name parts to format into a handle.
     /// @return handle The formatted ENS handle.
-    function _formatHandle(string[] memory ensNameParts) internal pure returns (string memory handle) {
+    function _formatHandle(
+        string[] memory ensNameParts
+    ) internal pure returns (string memory handle) {
         // Get a reference to the number of parts are in the ENS name.
         uint256 partsLength = ensNameParts.length;
 
         // Concatenate each name part.
         for (uint256 i = 1; i <= partsLength; i++) {
             // Compute the handle.
-            handle = string(abi.encodePacked(handle, ensNameParts[partsLength - i]));
+            handle = string(
+                abi.encodePacked(handle, ensNameParts[partsLength - i])
+            );
 
             // Add a dot if this part isn't the last.
             if (i < partsLength) handle = string(abi.encodePacked(handle, "."));
@@ -187,16 +202,25 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     /// @dev See https://eips.ethereum.org/EIPS/eip-137.
     /// @param ensNameParts The parts of an ENS name to hash.
     /// @return namehash The namehash for an ENS name parts.
-    function _namehash(string[] memory ensNameParts) internal pure returns (bytes32 namehash) {
+    function _namehash(
+        string[] memory ensNameParts
+    ) internal pure returns (bytes32 namehash) {
         // Hash the trailing "eth" suffix.
-        namehash = keccak256(abi.encodePacked(namehash, keccak256(abi.encodePacked("eth"))));
+        namehash = keccak256(
+            abi.encodePacked(namehash, keccak256(abi.encodePacked("eth")))
+        );
 
         // Get a reference to the number of parts are in the ENS name.
         uint256 nameLength = ensNameParts.length;
 
         // Hash each part.
         for (uint256 i; i < nameLength; i++) {
-            namehash = keccak256(abi.encodePacked(namehash, keccak256(abi.encodePacked(ensNameParts[i]))));
+            namehash = keccak256(
+                abi.encodePacked(
+                    namehash,
+                    keccak256(abi.encodePacked(ensNameParts[i]))
+                )
+            );
         }
     }
 
@@ -213,7 +237,13 @@ contract JBProjectHandles is IJBProjectHandles, ERC2771Context {
     }
 
     /// @dev ERC-2771 specifies the context as being a single address (20 bytes).
-    function _contextSuffixLength() internal view virtual override returns (uint256) {
+    function _contextSuffixLength()
+        internal
+        view
+        virtual
+        override
+        returns (uint256)
+    {
         return super._contextSuffixLength();
     }
 }

--- a/src/interfaces/IJBProjectHandles.sol
+++ b/src/interfaces/IJBProjectHandles.sol
@@ -5,24 +5,18 @@ import "@ensdomains/ens-contracts/contracts/resolvers/profiles/ITextResolver.sol
 import "@bananapus/core/src/interfaces/IJBProjects.sol";
 
 interface IJBProjectHandles {
-    event SetEnsNameParts(
-        uint256 indexed projectId,
-        string indexed handle,
-        string[] parts,
-        address caller
-    );
+    event SetEnsNameParts(uint256 indexed projectId, string indexed handle, string[] parts, address caller);
 
-    function setEnsNamePartsFor(
-        uint256 chainId,
-        uint256 projectId,
-        string[] memory parts
-    ) external;
+    function setEnsNamePartsFor(uint256 chainId, uint256 projectId, string[] memory parts) external;
 
     function ensNamePartsOf(
         uint256 chainId,
         uint256 projectId,
         address projectOwner
-    ) external view returns (string[] memory);
+    )
+        external
+        view
+        returns (string[] memory);
 
     function TEXT_KEY_PREFIX() external view returns (string memory);
 
@@ -32,9 +26,5 @@ interface IJBProjectHandles {
 
     function PROJECTS() external view returns (IJBProjects);
 
-    function handleOf(
-        uint256 chainId,
-        uint256 projectId,
-        address projectOwner
-    ) external view returns (string memory);
+    function handleOf(uint256 chainId, uint256 projectId, address projectOwner) external view returns (string memory);
 }

--- a/src/interfaces/IJBProjectHandles.sol
+++ b/src/interfaces/IJBProjectHandles.sol
@@ -5,32 +5,22 @@ import "@ensdomains/ens-contracts/contracts/resolvers/profiles/ITextResolver.sol
 import "@bananapus/core/src/interfaces/IJBProjects.sol";
 
 interface IJBProjectHandles {
-    event SetEnsNameParts(
-        uint256 indexed projectId,
-        string indexed handle,
-        string[] parts,
-        address caller
-    );
+    event SetEnsNameParts(uint256 indexed projectId, string indexed handle, string[] parts, address caller);
 
-    function setEnsNamePartsFor(
-        uint256 chainId,
-        uint256 projectId,
-        string[] memory parts
-    ) external;
+    function setEnsNamePartsFor(uint256 chainId, uint256 projectId, string[] memory parts) external;
 
     function ensNamePartsOf(
         uint256 chainId,
         uint256 projectId,
         address projectOwner
-    ) external view returns (string[] memory);
+    )
+        external
+        view
+        returns (string[] memory);
 
     function TEXT_KEY() external view returns (string memory);
 
     function PROJECTS() external view returns (IJBProjects);
 
-    function handleOf(
-        uint256 chainId,
-        uint256 projectId,
-        address projectOwner
-    ) external view returns (string memory);
+    function handleOf(uint256 chainId, uint256 projectId, address projectOwner) external view returns (string memory);
 }

--- a/src/interfaces/IJBProjectHandles.sol
+++ b/src/interfaces/IJBProjectHandles.sol
@@ -5,22 +5,36 @@ import "@ensdomains/ens-contracts/contracts/resolvers/profiles/ITextResolver.sol
 import "@bananapus/core/src/interfaces/IJBProjects.sol";
 
 interface IJBProjectHandles {
-    event SetEnsNameParts(uint256 indexed projectId, string indexed handle, string[] parts, address caller);
+    event SetEnsNameParts(
+        uint256 indexed projectId,
+        string indexed handle,
+        string[] parts,
+        address caller
+    );
 
-    function setEnsNamePartsFor(uint256 chainId, uint256 projectId, string[] memory parts) external;
+    function setEnsNamePartsFor(
+        uint256 chainId,
+        uint256 projectId,
+        string[] memory parts
+    ) external;
 
     function ensNamePartsOf(
         uint256 chainId,
         uint256 projectId,
         address projectOwner
-    )
-        external
-        view
-        returns (string[] memory);
+    ) external view returns (string[] memory);
 
-    function TEXT_KEY() external view returns (string memory);
+    function TEXT_KEY_PREFIX() external view returns (string memory);
+
+    function TEXT_KEY_PROJECT_ID_SUFFIX() external view returns (string memory);
+
+    function TEXT_KEY_CHAIN_ID_SUFFIX() external view returns (string memory);
 
     function PROJECTS() external view returns (IJBProjects);
 
-    function handleOf(uint256 chainId, uint256 projectId, address projectOwner) external view returns (string memory);
+    function handleOf(
+        uint256 chainId,
+        uint256 projectId,
+        address projectOwner
+    ) external view returns (string memory);
 }

--- a/src/interfaces/IJBProjectHandles.sol
+++ b/src/interfaces/IJBProjectHandles.sol
@@ -20,7 +20,5 @@ interface IJBProjectHandles {
 
     function TEXT_KEY() external view returns (string memory);
 
-    function PROJECTS() external view returns (IJBProjects);
-
     function handleOf(uint256 chainId, uint256 projectId, address projectOwner) external view returns (string memory);
 }

--- a/src/interfaces/IJBProjectHandles.sol
+++ b/src/interfaces/IJBProjectHandles.sol
@@ -5,26 +5,32 @@ import "@ensdomains/ens-contracts/contracts/resolvers/profiles/ITextResolver.sol
 import "@bananapus/core/src/interfaces/IJBProjects.sol";
 
 interface IJBProjectHandles {
-    event SetEnsNameParts(uint256 indexed projectId, string indexed handle, string[] parts, address caller);
+    event SetEnsNameParts(
+        uint256 indexed projectId,
+        string indexed handle,
+        string[] parts,
+        address caller
+    );
 
-    function setEnsNamePartsFor(uint256 chainId, uint256 projectId, string[] memory parts) external;
+    function setEnsNamePartsFor(
+        uint256 chainId,
+        uint256 projectId,
+        string[] memory parts
+    ) external;
 
     function ensNamePartsOf(
         uint256 chainId,
         uint256 projectId,
         address projectOwner
-    )
-        external
-        view
-        returns (string[] memory);
+    ) external view returns (string[] memory);
 
-    function TEXT_KEY_PREFIX() external view returns (string memory);
-
-    function TEXT_KEY_PROJECT_ID_SUFFIX() external view returns (string memory);
-
-    function TEXT_KEY_CHAIN_ID_SUFFIX() external view returns (string memory);
+    function TEXT_KEY() external view returns (string memory);
 
     function PROJECTS() external view returns (IJBProjects);
 
-    function handleOf(uint256 chainId, uint256 projectId, address projectOwner) external view returns (string memory);
+    function handleOf(
+        uint256 chainId,
+        uint256 projectId,
+        address projectOwner
+    ) external view returns (string memory);
 }

--- a/src/interfaces/IJBProjectHandles.sol
+++ b/src/interfaces/IJBProjectHandles.sol
@@ -7,13 +7,20 @@ import "@bananapus/core/src/interfaces/IJBProjects.sol";
 interface IJBProjectHandles {
     event SetEnsNameParts(uint256 indexed projectId, string indexed handle, string[] parts, address caller);
 
-    function setEnsNamePartsFor(uint256 _projectId, string[] memory _parts) external;
+    function setEnsNamePartsFor(uint256 chainId, uint256 projectId, string[] memory parts) external;
 
-    function ensNamePartsOf(uint256 _projectId) external view returns (string[] memory);
+    function ensNamePartsOf(
+        uint256 chainId,
+        uint256 projectId,
+        address projectOwner
+    )
+        external
+        view
+        returns (string[] memory);
 
     function TEXT_KEY() external view returns (string memory);
 
     function PROJECTS() external view returns (IJBProjects);
 
-    function handleOf(uint256 _projectId) external view returns (string memory);
+    function handleOf(uint256 chainId, uint256 projectId, address projectOwner) external view returns (string memory);
 }

--- a/test/JBProjectHandles.t.sol
+++ b/test/JBProjectHandles.t.sol
@@ -34,7 +34,7 @@ contract ContractTest is Test {
 
         jbPermissions = new JBPermissions();
         jbProjects = new JBProjects(address(69));
-        projectHandle = new JBProjectHandles(jbProjects, address(0x0));
+        projectHandle = new JBProjectHandles(address(0x0));
     }
 
     //*********************************************************************//

--- a/test/JBProjectHandles.t.sol
+++ b/test/JBProjectHandles.t.sol
@@ -186,15 +186,7 @@ contract ContractTest is Test {
         vm.mockCall(
             address(ensTextResolver),
             abi.encodeWithSelector(ITextResolver.text.selector, _namehash(nameParts), KEY),
-            abi.encode(
-                string.concat(
-                    Strings.toString(chainId),
-                    ":",
-                    Strings.toString(projectId),
-                    ":",
-                    Strings.toHexString(uint256(uint160(projectOwner)))
-                )
-            )
+            abi.encode(string.concat(Strings.toString(chainId), ":", Strings.toString(projectId)))
         );
 
         // Mock the registration on the previous version
@@ -319,15 +311,7 @@ contract ContractTest is Test {
         vm.mockCall(
             address(ensTextResolver),
             abi.encodeWithSelector(ITextResolver.text.selector, _namehash(nameParts), KEY),
-            abi.encode(
-                string.concat(
-                    Strings.toString(chainId),
-                    ":",
-                    Strings.toString(projectId),
-                    ":",
-                    Strings.toHexString(uint256(uint160(projectOwner)))
-                )
-            )
+            abi.encode(string.concat(Strings.toString(chainId), ":", Strings.toString(projectId)))
         );
 
         assertEq(

--- a/test/JBProjectHandles.t.sol
+++ b/test/JBProjectHandles.t.sol
@@ -13,11 +13,18 @@ import "../src/JBProjectHandles.sol";
 import {JBPermissionIds} from "@bananapus/permission-ids/src/JBPermissionIds.sol";
 
 ENS constant ensRegistry = ENS(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e);
-IJBProjectHandles constant oldHandle = IJBProjectHandles(0x41126eC99F8A989fEB503ac7bB4c5e5D40E06FA4);
+IJBProjectHandles constant oldHandle = IJBProjectHandles(
+    0x41126eC99F8A989fEB503ac7bB4c5e5D40E06FA4
+);
 
 contract ContractTest is Test {
     // For testing the event emitted
-    event SetEnsNameParts(uint256 indexed projectId, string indexed ensName, string[] parts, address caller);
+    event SetEnsNameParts(
+        uint256 indexed projectId,
+        string indexed ensName,
+        string[] parts,
+        address caller
+    );
 
     address projectOwner = address(6_942_069);
 
@@ -41,7 +48,9 @@ contract ContractTest is Test {
     // ------------------------ SetEnsNamePartsFor(..) ------------------- //
     //*********************************************************************//
 
-    function testSetEnsNamePartsFor_passIfCallerIsProjectOwnerAndOnlyName(string calldata name) public {
+    function testSetEnsNamePartsFor_passIfCallerIsProjectOwnerAndOnlyName(
+        string calldata name
+    ) public {
         vm.assume(bytes(name).length != 0);
 
         uint256 projectId = jbProjects.createFor(projectOwner);
@@ -58,17 +67,22 @@ contract ContractTest is Test {
         projectHandle.setEnsNamePartsFor(chainId, projectId, nameParts);
 
         // Control: correct ENS name?
-        assertEq(projectHandle.ensNamePartsOf(chainId, projectId, projectOwner), nameParts);
+        assertEq(
+            projectHandle.ensNamePartsOf(chainId, projectId, projectOwner),
+            nameParts
+        );
     }
 
     function testSetEnsNameWithSubdomainFor_passIfMultipleSubdomainLevels(
         string memory name,
         string memory subdomain,
         string memory subsubdomain
-    )
-        public
-    {
-        vm.assume(bytes(name).length > 0 && bytes(subdomain).length > 0 && bytes(subsubdomain).length > 0);
+    ) public {
+        vm.assume(
+            bytes(name).length > 0 &&
+                bytes(subdomain).length > 0 &&
+                bytes(subsubdomain).length > 0
+        );
 
         uint256 projectId = jbProjects.createFor(projectOwner);
         uint256 chainId = 1;
@@ -79,7 +93,9 @@ contract ContractTest is Test {
         nameParts[1] = subdomain;
         nameParts[2] = name;
 
-        string memory fullName = string(abi.encodePacked(name, ".", subdomain, ".", subsubdomain));
+        string memory fullName = string(
+            abi.encodePacked(name, ".", subdomain, ".", subsubdomain)
+        );
 
         // Test event
         vm.expectEmit(true, true, true, true);
@@ -89,17 +105,22 @@ contract ContractTest is Test {
         projectHandle.setEnsNamePartsFor(chainId, projectId, nameParts);
 
         // Control: ENS has correct name and domain
-        assertEq(projectHandle.ensNamePartsOf(chainId, projectId, projectOwner), nameParts);
+        assertEq(
+            projectHandle.ensNamePartsOf(chainId, projectId, projectOwner),
+            nameParts
+        );
     }
 
     function testSetEnsNameWithSubdomainFor_RevertIfEmptyElementInNameParts(
         string memory name,
         string memory subdomain,
         string memory subsubdomain
-    )
-        public
-    {
-        vm.assume(bytes(name).length == 0 || bytes(subdomain).length == 0 || bytes(subsubdomain).length == 0);
+    ) public {
+        vm.assume(
+            bytes(name).length == 0 ||
+                bytes(subdomain).length == 0 ||
+                bytes(subsubdomain).length == 0
+        );
 
         uint256 projectId = jbProjects.createFor(projectOwner);
         uint256 chainId = 1;
@@ -115,7 +136,10 @@ contract ContractTest is Test {
         projectHandle.setEnsNamePartsFor(chainId, projectId, nameParts);
 
         // Control: ENS has correct name and domain
-        assertEq(projectHandle.ensNamePartsOf(chainId, projectId, projectOwner), new string[](0));
+        assertEq(
+            projectHandle.ensNamePartsOf(chainId, projectId, projectOwner),
+            new string[](0)
+        );
     }
 
     function testSetEnsNameWithSubdomainFor_RevertIfEmptyNameParts() public {
@@ -130,18 +154,27 @@ contract ContractTest is Test {
         projectHandle.setEnsNamePartsFor(chainId, projectId, nameParts);
 
         // Control: ENS has correct name and domain
-        assertEq(projectHandle.ensNamePartsOf(chainId, projectId, projectOwner), new string[](0));
+        assertEq(
+            projectHandle.ensNamePartsOf(chainId, projectId, projectOwner),
+            new string[](0)
+        );
     }
 
     //*********************************************************************//
     // ---------------------------- handleOf(..) ------------------------- //
     //*********************************************************************//
 
-    function testHandleOf_returnsEmptyStringIfNoHandleSet(uint256 chainId, uint256 projectId) public {
+    function testHandleOf_returnsEmptyStringIfNoHandleSet(
+        uint256 chainId,
+        uint256 projectId
+    ) public {
         // No handle set on the previous JBProjectHandle version neither
         vm.mockCall(
             address(oldHandle),
-            abi.encodeCall(IJBProjectHandles.ensNamePartsOf, (chainId, projectId, projectOwner)),
+            abi.encodeCall(
+                IJBProjectHandles.ensNamePartsOf,
+                (chainId, projectId, projectOwner)
+            ),
             abi.encode(new string[](0))
         );
 
@@ -152,15 +185,17 @@ contract ContractTest is Test {
         string calldata name,
         string calldata subdomain,
         string calldata subsubdomain
-    )
-        public
-    {
-        vm.assume(bytes(name).length > 0 && bytes(subdomain).length > 0 && bytes(subsubdomain).length > 0);
+    ) public {
+        vm.assume(
+            bytes(name).length > 0 &&
+                bytes(subdomain).length > 0 &&
+                bytes(subsubdomain).length > 0
+        );
 
         uint256 projectId = jbProjects.createFor(projectOwner);
         uint256 chainId = 1;
 
-        string memory KEY = projectHandle.TEXT_KEY_PREFIX();
+        string memory KEY = projectHandle.TEXT_KEY();
 
         // name.subdomain.subsubdomain.eth is stored as ['subsubdomain', 'subdomain', 'domain']
         string[] memory nameParts = new string[](3);
@@ -185,20 +220,29 @@ contract ContractTest is Test {
 
         vm.mockCall(
             address(ensTextResolver),
-            abi.encodeWithSelector(ITextResolver.text.selector, _namehash(nameParts), string.concat(KEY, ":projectId")),
-            abi.encode(Strings.toString(projectId))
-        );
-
-        vm.mockCall(
-            address(ensTextResolver),
-            abi.encodeWithSelector(ITextResolver.text.selector, _namehash(nameParts), string.concat(KEY, ":chainId")),
-            abi.encode(Strings.toString(chainId))
+            abi.encodeWithSelector(
+                ITextResolver.text.selector,
+                _namehash(nameParts),
+                KEY
+            ),
+            abi.encode(
+                string.concat(
+                    Strings.toString(chainId),
+                    ":",
+                    Strings.toString(projectId),
+                    ":",
+                    Strings.toHexString(uint256(uint160(projectOwner)))
+                )
+            )
         );
 
         // Mock the registration on the previous version
         vm.mockCall(
             address(oldHandle),
-            abi.encodeCall(IJBProjectHandles.ensNamePartsOf, (chainId, projectId, projectOwner)),
+            abi.encodeCall(
+                IJBProjectHandles.ensNamePartsOf,
+                (chainId, projectId, projectOwner)
+            ),
             abi.encode(oldNamePart)
         );
 
@@ -216,15 +260,16 @@ contract ContractTest is Test {
         string calldata name,
         string calldata subdomain,
         string calldata subsubdomain
-    )
-        public
-    {
+    ) public {
         vm.assume(projectId != reverseId);
 
         // No handle set on the previous JBProjectHandle version
         vm.mockCall(
             address(oldHandle),
-            abi.encodeCall(IJBProjectHandles.ensNamePartsOf, (chainId, projectId, projectOwner)),
+            abi.encodeCall(
+                IJBProjectHandles.ensNamePartsOf,
+                (chainId, projectId, projectOwner)
+            ),
             abi.encode(new string[](0))
         );
 
@@ -250,19 +295,20 @@ contract ContractTest is Test {
         string calldata name,
         string calldata subdomain,
         string calldata subsubdomain
-    )
-        public
-    {
+    ) public {
         vm.assume(projectId != reverseId);
 
         // No handle set on the previous JBProjectHandle version
         vm.mockCall(
             address(oldHandle),
-            abi.encodeCall(IJBProjectHandles.ensNamePartsOf, (chainId, projectId, projectOwner)),
+            abi.encodeCall(
+                IJBProjectHandles.ensNamePartsOf,
+                (chainId, projectId, projectOwner)
+            ),
             abi.encode(new string[](0))
         );
 
-        string memory KEY = projectHandle.TEXT_KEY_PREFIX();
+        string memory KEY = projectHandle.TEXT_KEY();
 
         // name.subdomain.subsubdomain.eth is stored as ['subsubdomain', 'subdomain', 'domain']
         string[] memory nameParts = new string[](3);
@@ -278,7 +324,11 @@ contract ContractTest is Test {
 
         vm.mockCall(
             address(ensTextResolver),
-            abi.encodeWithSelector(ITextResolver.text.selector, _namehash(nameParts), KEY),
+            abi.encodeWithSelector(
+                ITextResolver.text.selector,
+                _namehash(nameParts),
+                KEY
+            ),
             abi.encode(Strings.toString(reverseId))
         );
 
@@ -289,15 +339,17 @@ contract ContractTest is Test {
         string calldata name,
         string calldata subdomain,
         string calldata subsubdomain
-    )
-        public
-    {
-        vm.assume(bytes(name).length > 0 && bytes(subdomain).length > 0 && bytes(subsubdomain).length > 0);
+    ) public {
+        vm.assume(
+            bytes(name).length > 0 &&
+                bytes(subdomain).length > 0 &&
+                bytes(subsubdomain).length > 0
+        );
 
         uint256 projectId = jbProjects.createFor(projectOwner);
         uint256 chainId = 1;
 
-        string memory KEY = projectHandle.TEXT_KEY_PREFIX();
+        string memory KEY = projectHandle.TEXT_KEY();
 
         // name.subdomain.subsubdomain.eth is stored as ['subsubdomain', 'subdomain', 'domain']
         string[] memory nameParts = new string[](3);
@@ -316,14 +368,20 @@ contract ContractTest is Test {
 
         vm.mockCall(
             address(ensTextResolver),
-            abi.encodeWithSelector(ITextResolver.text.selector, _namehash(nameParts), string.concat(KEY, ":projectId")),
-            abi.encode(Strings.toString(projectId))
-        );
-
-        vm.mockCall(
-            address(ensTextResolver),
-            abi.encodeWithSelector(ITextResolver.text.selector, _namehash(nameParts), string.concat(KEY, ":chainId")),
-            abi.encode(Strings.toString(chainId))
+            abi.encodeWithSelector(
+                ITextResolver.text.selector,
+                _namehash(nameParts),
+                KEY
+            ),
+            abi.encode(
+                string.concat(
+                    Strings.toString(chainId),
+                    ":",
+                    Strings.toString(projectId),
+                    ":",
+                    Strings.toHexString(uint256(uint160(projectOwner)))
+                )
+            )
         );
 
         assertEq(
@@ -344,15 +402,24 @@ contract ContractTest is Test {
         }
     }
 
-    function _namehash(string[] memory ensName) internal pure returns (bytes32 namehash) {
-        namehash = keccak256(abi.encodePacked(namehash, keccak256(abi.encodePacked("eth"))));
+    function _namehash(
+        string[] memory ensName
+    ) internal pure returns (bytes32 namehash) {
+        namehash = keccak256(
+            abi.encodePacked(namehash, keccak256(abi.encodePacked("eth")))
+        );
 
         // Get a reference to the number of parts are in the ENS name.
         uint256 nameLength = ensName.length;
 
         // Hash each part.
         for (uint256 i = 0; i < nameLength; i++) {
-            namehash = keccak256(abi.encodePacked(namehash, keccak256(abi.encodePacked(ensName[i]))));
+            namehash = keccak256(
+                abi.encodePacked(
+                    namehash,
+                    keccak256(abi.encodePacked(ensName[i]))
+                )
+            );
         }
     }
 }

--- a/test/JBProjectHandles.t.sol
+++ b/test/JBProjectHandles.t.sol
@@ -13,18 +13,11 @@ import "../src/JBProjectHandles.sol";
 import {JBPermissionIds} from "@bananapus/permission-ids/src/JBPermissionIds.sol";
 
 ENS constant ensRegistry = ENS(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e);
-IJBProjectHandles constant oldHandle = IJBProjectHandles(
-    0x41126eC99F8A989fEB503ac7bB4c5e5D40E06FA4
-);
+IJBProjectHandles constant oldHandle = IJBProjectHandles(0x41126eC99F8A989fEB503ac7bB4c5e5D40E06FA4);
 
 contract ContractTest is Test {
     // For testing the event emitted
-    event SetEnsNameParts(
-        uint256 indexed projectId,
-        string indexed ensName,
-        string[] parts,
-        address caller
-    );
+    event SetEnsNameParts(uint256 indexed projectId, string indexed ensName, string[] parts, address caller);
 
     address projectOwner = address(6_942_069);
 
@@ -48,9 +41,7 @@ contract ContractTest is Test {
     // ------------------------ SetEnsNamePartsFor(..) ------------------- //
     //*********************************************************************//
 
-    function testSetEnsNamePartsFor_passIfCallerIsProjectOwnerAndOnlyName(
-        string calldata name
-    ) public {
+    function testSetEnsNamePartsFor_passIfCallerIsProjectOwnerAndOnlyName(string calldata name) public {
         vm.assume(bytes(name).length != 0);
 
         uint256 projectId = jbProjects.createFor(projectOwner);
@@ -67,22 +58,17 @@ contract ContractTest is Test {
         projectHandle.setEnsNamePartsFor(chainId, projectId, nameParts);
 
         // Control: correct ENS name?
-        assertEq(
-            projectHandle.ensNamePartsOf(chainId, projectId, projectOwner),
-            nameParts
-        );
+        assertEq(projectHandle.ensNamePartsOf(chainId, projectId, projectOwner), nameParts);
     }
 
     function testSetEnsNameWithSubdomainFor_passIfMultipleSubdomainLevels(
         string memory name,
         string memory subdomain,
         string memory subsubdomain
-    ) public {
-        vm.assume(
-            bytes(name).length > 0 &&
-                bytes(subdomain).length > 0 &&
-                bytes(subsubdomain).length > 0
-        );
+    )
+        public
+    {
+        vm.assume(bytes(name).length > 0 && bytes(subdomain).length > 0 && bytes(subsubdomain).length > 0);
 
         uint256 projectId = jbProjects.createFor(projectOwner);
         uint256 chainId = 1;
@@ -93,9 +79,7 @@ contract ContractTest is Test {
         nameParts[1] = subdomain;
         nameParts[2] = name;
 
-        string memory fullName = string(
-            abi.encodePacked(name, ".", subdomain, ".", subsubdomain)
-        );
+        string memory fullName = string(abi.encodePacked(name, ".", subdomain, ".", subsubdomain));
 
         // Test event
         vm.expectEmit(true, true, true, true);
@@ -105,22 +89,17 @@ contract ContractTest is Test {
         projectHandle.setEnsNamePartsFor(chainId, projectId, nameParts);
 
         // Control: ENS has correct name and domain
-        assertEq(
-            projectHandle.ensNamePartsOf(chainId, projectId, projectOwner),
-            nameParts
-        );
+        assertEq(projectHandle.ensNamePartsOf(chainId, projectId, projectOwner), nameParts);
     }
 
     function testSetEnsNameWithSubdomainFor_RevertIfEmptyElementInNameParts(
         string memory name,
         string memory subdomain,
         string memory subsubdomain
-    ) public {
-        vm.assume(
-            bytes(name).length == 0 ||
-                bytes(subdomain).length == 0 ||
-                bytes(subsubdomain).length == 0
-        );
+    )
+        public
+    {
+        vm.assume(bytes(name).length == 0 || bytes(subdomain).length == 0 || bytes(subsubdomain).length == 0);
 
         uint256 projectId = jbProjects.createFor(projectOwner);
         uint256 chainId = 1;
@@ -136,10 +115,7 @@ contract ContractTest is Test {
         projectHandle.setEnsNamePartsFor(chainId, projectId, nameParts);
 
         // Control: ENS has correct name and domain
-        assertEq(
-            projectHandle.ensNamePartsOf(chainId, projectId, projectOwner),
-            new string[](0)
-        );
+        assertEq(projectHandle.ensNamePartsOf(chainId, projectId, projectOwner), new string[](0));
     }
 
     function testSetEnsNameWithSubdomainFor_RevertIfEmptyNameParts() public {
@@ -154,27 +130,18 @@ contract ContractTest is Test {
         projectHandle.setEnsNamePartsFor(chainId, projectId, nameParts);
 
         // Control: ENS has correct name and domain
-        assertEq(
-            projectHandle.ensNamePartsOf(chainId, projectId, projectOwner),
-            new string[](0)
-        );
+        assertEq(projectHandle.ensNamePartsOf(chainId, projectId, projectOwner), new string[](0));
     }
 
     //*********************************************************************//
     // ---------------------------- handleOf(..) ------------------------- //
     //*********************************************************************//
 
-    function testHandleOf_returnsEmptyStringIfNoHandleSet(
-        uint256 chainId,
-        uint256 projectId
-    ) public {
+    function testHandleOf_returnsEmptyStringIfNoHandleSet(uint256 chainId, uint256 projectId) public {
         // No handle set on the previous JBProjectHandle version neither
         vm.mockCall(
             address(oldHandle),
-            abi.encodeCall(
-                IJBProjectHandles.ensNamePartsOf,
-                (chainId, projectId, projectOwner)
-            ),
+            abi.encodeCall(IJBProjectHandles.ensNamePartsOf, (chainId, projectId, projectOwner)),
             abi.encode(new string[](0))
         );
 
@@ -185,12 +152,10 @@ contract ContractTest is Test {
         string calldata name,
         string calldata subdomain,
         string calldata subsubdomain
-    ) public {
-        vm.assume(
-            bytes(name).length > 0 &&
-                bytes(subdomain).length > 0 &&
-                bytes(subsubdomain).length > 0
-        );
+    )
+        public
+    {
+        vm.assume(bytes(name).length > 0 && bytes(subdomain).length > 0 && bytes(subsubdomain).length > 0);
 
         uint256 projectId = jbProjects.createFor(projectOwner);
         uint256 chainId = 1;
@@ -220,11 +185,7 @@ contract ContractTest is Test {
 
         vm.mockCall(
             address(ensTextResolver),
-            abi.encodeWithSelector(
-                ITextResolver.text.selector,
-                _namehash(nameParts),
-                KEY
-            ),
+            abi.encodeWithSelector(ITextResolver.text.selector, _namehash(nameParts), KEY),
             abi.encode(
                 string.concat(
                     Strings.toString(chainId),
@@ -239,10 +200,7 @@ contract ContractTest is Test {
         // Mock the registration on the previous version
         vm.mockCall(
             address(oldHandle),
-            abi.encodeCall(
-                IJBProjectHandles.ensNamePartsOf,
-                (chainId, projectId, projectOwner)
-            ),
+            abi.encodeCall(IJBProjectHandles.ensNamePartsOf, (chainId, projectId, projectOwner)),
             abi.encode(oldNamePart)
         );
 
@@ -260,16 +218,15 @@ contract ContractTest is Test {
         string calldata name,
         string calldata subdomain,
         string calldata subsubdomain
-    ) public {
+    )
+        public
+    {
         vm.assume(projectId != reverseId);
 
         // No handle set on the previous JBProjectHandle version
         vm.mockCall(
             address(oldHandle),
-            abi.encodeCall(
-                IJBProjectHandles.ensNamePartsOf,
-                (chainId, projectId, projectOwner)
-            ),
+            abi.encodeCall(IJBProjectHandles.ensNamePartsOf, (chainId, projectId, projectOwner)),
             abi.encode(new string[](0))
         );
 
@@ -295,16 +252,15 @@ contract ContractTest is Test {
         string calldata name,
         string calldata subdomain,
         string calldata subsubdomain
-    ) public {
+    )
+        public
+    {
         vm.assume(projectId != reverseId);
 
         // No handle set on the previous JBProjectHandle version
         vm.mockCall(
             address(oldHandle),
-            abi.encodeCall(
-                IJBProjectHandles.ensNamePartsOf,
-                (chainId, projectId, projectOwner)
-            ),
+            abi.encodeCall(IJBProjectHandles.ensNamePartsOf, (chainId, projectId, projectOwner)),
             abi.encode(new string[](0))
         );
 
@@ -324,11 +280,7 @@ contract ContractTest is Test {
 
         vm.mockCall(
             address(ensTextResolver),
-            abi.encodeWithSelector(
-                ITextResolver.text.selector,
-                _namehash(nameParts),
-                KEY
-            ),
+            abi.encodeWithSelector(ITextResolver.text.selector, _namehash(nameParts), KEY),
             abi.encode(Strings.toString(reverseId))
         );
 
@@ -339,12 +291,10 @@ contract ContractTest is Test {
         string calldata name,
         string calldata subdomain,
         string calldata subsubdomain
-    ) public {
-        vm.assume(
-            bytes(name).length > 0 &&
-                bytes(subdomain).length > 0 &&
-                bytes(subsubdomain).length > 0
-        );
+    )
+        public
+    {
+        vm.assume(bytes(name).length > 0 && bytes(subdomain).length > 0 && bytes(subsubdomain).length > 0);
 
         uint256 projectId = jbProjects.createFor(projectOwner);
         uint256 chainId = 1;
@@ -368,11 +318,7 @@ contract ContractTest is Test {
 
         vm.mockCall(
             address(ensTextResolver),
-            abi.encodeWithSelector(
-                ITextResolver.text.selector,
-                _namehash(nameParts),
-                KEY
-            ),
+            abi.encodeWithSelector(ITextResolver.text.selector, _namehash(nameParts), KEY),
             abi.encode(
                 string.concat(
                     Strings.toString(chainId),
@@ -402,24 +348,15 @@ contract ContractTest is Test {
         }
     }
 
-    function _namehash(
-        string[] memory ensName
-    ) internal pure returns (bytes32 namehash) {
-        namehash = keccak256(
-            abi.encodePacked(namehash, keccak256(abi.encodePacked("eth")))
-        );
+    function _namehash(string[] memory ensName) internal pure returns (bytes32 namehash) {
+        namehash = keccak256(abi.encodePacked(namehash, keccak256(abi.encodePacked("eth"))));
 
         // Get a reference to the number of parts are in the ENS name.
         uint256 nameLength = ensName.length;
 
         // Hash each part.
         for (uint256 i = 0; i < nameLength; i++) {
-            namehash = keccak256(
-                abi.encodePacked(
-                    namehash,
-                    keccak256(abi.encodePacked(ensName[i]))
-                )
-            );
+            namehash = keccak256(abi.encodePacked(namehash, keccak256(abi.encodePacked(ensName[i]))));
         }
     }
 }

--- a/test/JBProjectHandles.t.sol
+++ b/test/JBProjectHandles.t.sol
@@ -195,7 +195,7 @@ contract ContractTest is Test {
         uint256 projectId = jbProjects.createFor(projectOwner);
         uint256 chainId = 1;
 
-        string memory KEY = projectHandle.TEXT_KEY();
+        string memory KEY = projectHandle.TEXT_KEY_PREFIX();
 
         // name.subdomain.subsubdomain.eth is stored as ['subsubdomain', 'subdomain', 'domain']
         string[] memory nameParts = new string[](3);
@@ -310,7 +310,7 @@ contract ContractTest is Test {
             abi.encode(new string[](0))
         );
 
-        string memory KEY = projectHandle.TEXT_KEY();
+        string memory KEY = projectHandle.TEXT_KEY_PREFIX();
 
         // name.subdomain.subsubdomain.eth is stored as ['subsubdomain', 'subdomain', 'domain']
         string[] memory nameParts = new string[](3);
@@ -351,7 +351,7 @@ contract ContractTest is Test {
         uint256 projectId = jbProjects.createFor(projectOwner);
         uint256 chainId = 1;
 
-        string memory KEY = projectHandle.TEXT_KEY();
+        string memory KEY = projectHandle.TEXT_KEY_PREFIX();
 
         // name.subdomain.subsubdomain.eth is stored as ['subsubdomain', 'subdomain', 'domain']
         string[] memory nameParts = new string[](3);

--- a/test/JBProjectHandles.t.sol
+++ b/test/JBProjectHandles.t.sol
@@ -13,18 +13,11 @@ import "../src/JBProjectHandles.sol";
 import {JBPermissionIds} from "@bananapus/permission-ids/src/JBPermissionIds.sol";
 
 ENS constant ensRegistry = ENS(0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e);
-IJBProjectHandles constant oldHandle = IJBProjectHandles(
-    0x41126eC99F8A989fEB503ac7bB4c5e5D40E06FA4
-);
+IJBProjectHandles constant oldHandle = IJBProjectHandles(0x41126eC99F8A989fEB503ac7bB4c5e5D40E06FA4);
 
 contract ContractTest is Test {
     // For testing the event emitted
-    event SetEnsNameParts(
-        uint256 indexed projectId,
-        string indexed ensName,
-        string[] parts,
-        address caller
-    );
+    event SetEnsNameParts(uint256 indexed projectId, string indexed ensName, string[] parts, address caller);
 
     address projectOwner = address(6_942_069);
 
@@ -48,9 +41,7 @@ contract ContractTest is Test {
     // ------------------------ SetEnsNamePartsFor(..) ------------------- //
     //*********************************************************************//
 
-    function testSetEnsNamePartsFor_passIfCallerIsProjectOwnerAndOnlyName(
-        string calldata name
-    ) public {
+    function testSetEnsNamePartsFor_passIfCallerIsProjectOwnerAndOnlyName(string calldata name) public {
         vm.assume(bytes(name).length != 0);
 
         uint256 projectId = jbProjects.createFor(projectOwner);
@@ -67,22 +58,17 @@ contract ContractTest is Test {
         projectHandle.setEnsNamePartsFor(chainId, projectId, nameParts);
 
         // Control: correct ENS name?
-        assertEq(
-            projectHandle.ensNamePartsOf(chainId, projectId, projectOwner),
-            nameParts
-        );
+        assertEq(projectHandle.ensNamePartsOf(chainId, projectId, projectOwner), nameParts);
     }
 
     function testSetEnsNameWithSubdomainFor_passIfMultipleSubdomainLevels(
         string memory name,
         string memory subdomain,
         string memory subsubdomain
-    ) public {
-        vm.assume(
-            bytes(name).length > 0 &&
-                bytes(subdomain).length > 0 &&
-                bytes(subsubdomain).length > 0
-        );
+    )
+        public
+    {
+        vm.assume(bytes(name).length > 0 && bytes(subdomain).length > 0 && bytes(subsubdomain).length > 0);
 
         uint256 projectId = jbProjects.createFor(projectOwner);
         uint256 chainId = 1;
@@ -93,9 +79,7 @@ contract ContractTest is Test {
         nameParts[1] = subdomain;
         nameParts[2] = name;
 
-        string memory fullName = string(
-            abi.encodePacked(name, ".", subdomain, ".", subsubdomain)
-        );
+        string memory fullName = string(abi.encodePacked(name, ".", subdomain, ".", subsubdomain));
 
         // Test event
         vm.expectEmit(true, true, true, true);
@@ -105,22 +89,17 @@ contract ContractTest is Test {
         projectHandle.setEnsNamePartsFor(chainId, projectId, nameParts);
 
         // Control: ENS has correct name and domain
-        assertEq(
-            projectHandle.ensNamePartsOf(chainId, projectId, projectOwner),
-            nameParts
-        );
+        assertEq(projectHandle.ensNamePartsOf(chainId, projectId, projectOwner), nameParts);
     }
 
     function testSetEnsNameWithSubdomainFor_RevertIfEmptyElementInNameParts(
         string memory name,
         string memory subdomain,
         string memory subsubdomain
-    ) public {
-        vm.assume(
-            bytes(name).length == 0 ||
-                bytes(subdomain).length == 0 ||
-                bytes(subsubdomain).length == 0
-        );
+    )
+        public
+    {
+        vm.assume(bytes(name).length == 0 || bytes(subdomain).length == 0 || bytes(subsubdomain).length == 0);
 
         uint256 projectId = jbProjects.createFor(projectOwner);
         uint256 chainId = 1;
@@ -136,10 +115,7 @@ contract ContractTest is Test {
         projectHandle.setEnsNamePartsFor(chainId, projectId, nameParts);
 
         // Control: ENS has correct name and domain
-        assertEq(
-            projectHandle.ensNamePartsOf(chainId, projectId, projectOwner),
-            new string[](0)
-        );
+        assertEq(projectHandle.ensNamePartsOf(chainId, projectId, projectOwner), new string[](0));
     }
 
     function testSetEnsNameWithSubdomainFor_RevertIfEmptyNameParts() public {
@@ -154,27 +130,18 @@ contract ContractTest is Test {
         projectHandle.setEnsNamePartsFor(chainId, projectId, nameParts);
 
         // Control: ENS has correct name and domain
-        assertEq(
-            projectHandle.ensNamePartsOf(chainId, projectId, projectOwner),
-            new string[](0)
-        );
+        assertEq(projectHandle.ensNamePartsOf(chainId, projectId, projectOwner), new string[](0));
     }
 
     //*********************************************************************//
     // ---------------------------- handleOf(..) ------------------------- //
     //*********************************************************************//
 
-    function testHandleOf_returnsEmptyStringIfNoHandleSet(
-        uint256 chainId,
-        uint256 projectId
-    ) public {
+    function testHandleOf_returnsEmptyStringIfNoHandleSet(uint256 chainId, uint256 projectId) public {
         // No handle set on the previous JBProjectHandle version neither
         vm.mockCall(
             address(oldHandle),
-            abi.encodeCall(
-                IJBProjectHandles.ensNamePartsOf,
-                (chainId, projectId, projectOwner)
-            ),
+            abi.encodeCall(IJBProjectHandles.ensNamePartsOf, (chainId, projectId, projectOwner)),
             abi.encode(new string[](0))
         );
 
@@ -185,12 +152,10 @@ contract ContractTest is Test {
         string calldata name,
         string calldata subdomain,
         string calldata subsubdomain
-    ) public {
-        vm.assume(
-            bytes(name).length > 0 &&
-                bytes(subdomain).length > 0 &&
-                bytes(subsubdomain).length > 0
-        );
+    )
+        public
+    {
+        vm.assume(bytes(name).length > 0 && bytes(subdomain).length > 0 && bytes(subsubdomain).length > 0);
 
         uint256 projectId = jbProjects.createFor(projectOwner);
         uint256 chainId = 1;
@@ -220,31 +185,20 @@ contract ContractTest is Test {
 
         vm.mockCall(
             address(ensTextResolver),
-            abi.encodeWithSelector(
-                ITextResolver.text.selector,
-                _namehash(nameParts),
-                string.concat(KEY, ":projectId")
-            ),
+            abi.encodeWithSelector(ITextResolver.text.selector, _namehash(nameParts), string.concat(KEY, ":projectId")),
             abi.encode(Strings.toString(projectId))
         );
 
         vm.mockCall(
             address(ensTextResolver),
-            abi.encodeWithSelector(
-                ITextResolver.text.selector,
-                _namehash(nameParts),
-                string.concat(KEY, ":chainId")
-            ),
+            abi.encodeWithSelector(ITextResolver.text.selector, _namehash(nameParts), string.concat(KEY, ":chainId")),
             abi.encode(Strings.toString(chainId))
         );
 
         // Mock the registration on the previous version
         vm.mockCall(
             address(oldHandle),
-            abi.encodeCall(
-                IJBProjectHandles.ensNamePartsOf,
-                (chainId, projectId, projectOwner)
-            ),
+            abi.encodeCall(IJBProjectHandles.ensNamePartsOf, (chainId, projectId, projectOwner)),
             abi.encode(oldNamePart)
         );
 
@@ -262,16 +216,15 @@ contract ContractTest is Test {
         string calldata name,
         string calldata subdomain,
         string calldata subsubdomain
-    ) public {
+    )
+        public
+    {
         vm.assume(projectId != reverseId);
 
         // No handle set on the previous JBProjectHandle version
         vm.mockCall(
             address(oldHandle),
-            abi.encodeCall(
-                IJBProjectHandles.ensNamePartsOf,
-                (chainId, projectId, projectOwner)
-            ),
+            abi.encodeCall(IJBProjectHandles.ensNamePartsOf, (chainId, projectId, projectOwner)),
             abi.encode(new string[](0))
         );
 
@@ -297,16 +250,15 @@ contract ContractTest is Test {
         string calldata name,
         string calldata subdomain,
         string calldata subsubdomain
-    ) public {
+    )
+        public
+    {
         vm.assume(projectId != reverseId);
 
         // No handle set on the previous JBProjectHandle version
         vm.mockCall(
             address(oldHandle),
-            abi.encodeCall(
-                IJBProjectHandles.ensNamePartsOf,
-                (chainId, projectId, projectOwner)
-            ),
+            abi.encodeCall(IJBProjectHandles.ensNamePartsOf, (chainId, projectId, projectOwner)),
             abi.encode(new string[](0))
         );
 
@@ -326,11 +278,7 @@ contract ContractTest is Test {
 
         vm.mockCall(
             address(ensTextResolver),
-            abi.encodeWithSelector(
-                ITextResolver.text.selector,
-                _namehash(nameParts),
-                KEY
-            ),
+            abi.encodeWithSelector(ITextResolver.text.selector, _namehash(nameParts), KEY),
             abi.encode(Strings.toString(reverseId))
         );
 
@@ -341,12 +289,10 @@ contract ContractTest is Test {
         string calldata name,
         string calldata subdomain,
         string calldata subsubdomain
-    ) public {
-        vm.assume(
-            bytes(name).length > 0 &&
-                bytes(subdomain).length > 0 &&
-                bytes(subsubdomain).length > 0
-        );
+    )
+        public
+    {
+        vm.assume(bytes(name).length > 0 && bytes(subdomain).length > 0 && bytes(subsubdomain).length > 0);
 
         uint256 projectId = jbProjects.createFor(projectOwner);
         uint256 chainId = 1;
@@ -370,21 +316,13 @@ contract ContractTest is Test {
 
         vm.mockCall(
             address(ensTextResolver),
-            abi.encodeWithSelector(
-                ITextResolver.text.selector,
-                _namehash(nameParts),
-                string.concat(KEY, ":projectId")
-            ),
+            abi.encodeWithSelector(ITextResolver.text.selector, _namehash(nameParts), string.concat(KEY, ":projectId")),
             abi.encode(Strings.toString(projectId))
         );
 
         vm.mockCall(
             address(ensTextResolver),
-            abi.encodeWithSelector(
-                ITextResolver.text.selector,
-                _namehash(nameParts),
-                string.concat(KEY, ":chainId")
-            ),
+            abi.encodeWithSelector(ITextResolver.text.selector, _namehash(nameParts), string.concat(KEY, ":chainId")),
             abi.encode(Strings.toString(chainId))
         );
 
@@ -406,24 +344,15 @@ contract ContractTest is Test {
         }
     }
 
-    function _namehash(
-        string[] memory ensName
-    ) internal pure returns (bytes32 namehash) {
-        namehash = keccak256(
-            abi.encodePacked(namehash, keccak256(abi.encodePacked("eth")))
-        );
+    function _namehash(string[] memory ensName) internal pure returns (bytes32 namehash) {
+        namehash = keccak256(abi.encodePacked(namehash, keccak256(abi.encodePacked("eth"))));
 
         // Get a reference to the number of parts are in the ENS name.
         uint256 nameLength = ensName.length;
 
         // Hash each part.
         for (uint256 i = 0; i < nameLength; i++) {
-            namehash = keccak256(
-                abi.encodePacked(
-                    namehash,
-                    keccak256(abi.encodePacked(ensName[i]))
-                )
-            );
+            namehash = keccak256(abi.encodePacked(namehash, keccak256(abi.encodePacked(ensName[i]))));
         }
     }
 }


### PR DESCRIPTION
# Description

TLDR: allows an ENS record to point to a specific projectId on a specific chainId. i.e. @jango points to project 33 on Op.

The ENS records now returns a projectId and the chainId on which the projectId should be resolved.
In order to do this, we remove the Permission check since we cant know who owns a projectId on a different chain, and instead allow anyone to set records for any project on any chain, BUT the record will be set relative to the msg.sender. Clients are advised to request matches only for a project's current project owner if they wish to resolve records set by the project owner.

The new ENS record keys are "juicebox:projectId" and "juicebox:chainId". 

To be clear, this contract is only meant to be deployed on the chain where the ENS registry lives -- likely only mainnet to start.

## Limitations & risks

*Are there any trade-off or new vulnarbility surface based on theses changes?*

# Check-list
- [ ] Tests are covering the new feature
- [ ] Code is [natspec'd](https://docs.soliditylang.org/en/v0.8.17/natspec-format.html)
- [ ] Code is [linted and formatted](https://docs.soliditylang.org/en/v0.8.17/style-guide.html)
- [ ] I have run the test locally (and they pass)
- [ ] I have rebased to the latest main commit (and tests still pass)

# Interactions
These changes will impact the following contracts:
- Directly:

- Indirectly: